### PR TITLE
fix: removing element from an array doesn't insert null anymore #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ commonjs
 es
 test/test.js
 npm-debug.log
+.idea

--- a/immupdate.ts
+++ b/immupdate.ts
@@ -158,8 +158,13 @@ class _Updater {
     let modified = structurallyModified
 
     if (value === DELETE) {
-      
-      if (leafHostIsOption) {
+
+      if (Array.isArray(leafHost) && typeof field === 'number') {
+        if (field >= leafHost.length) return target
+        modified = true
+        leafHost.splice(field, 1)
+      }
+      else if (leafHostIsOption) {
         if (field in leafHost.value) modified = true
         delete leafHost.value[field]
       }
@@ -253,7 +258,7 @@ class _Updater {
         const nextValue = clone(value)
         const newHost = isLast ? host : nextValue
 
-        host[this.data.field] = nextValue
+        if (nextValue !== undefined) host[this.data.field] = nextValue
 
         return { host: newHost, field: newField }
       }

--- a/test/test.ts
+++ b/test/test.ts
@@ -655,6 +655,26 @@ describe('immupdate', () => {
       expect(updated4).toNotBe(obj2)
     })
 
+    it('can delete an element of an array', () => {
+
+      type TestType = {a: number[]}
+      const data: TestType = {a: [1, 2, 3]}
+
+      // test if the element to delete exist
+      const expected1: TestType = {a: [1, 3]}
+      const updated1 = deepUpdate(data).at('a').at(1).set(DELETE)
+      expect(updated1).toEqual(expected1)
+      expect(updated1).toNotBe(data)
+
+      // test if nothing happen when the element to delete is out of array's bound
+      const updated2 = deepUpdate(data).at('a').at(3).set(DELETE)
+      expect(updated2).toEqual(data)
+
+      // test if nothing happen when the element to delete is widely out of array's bound
+      const updated3 = deepUpdate(data).at('a').at(5).set(DELETE)
+      expect(updated3).toEqual(data)
+    })
+
     it('can update an union member with an instance of this union', () => {
 
       type A = { type: 'a', data: number }

--- a/test/test.ts
+++ b/test/test.ts
@@ -660,19 +660,31 @@ describe('immupdate', () => {
       type TestType = {a: number[]}
       const data: TestType = {a: [1, 2, 3]}
 
-      // test if the element to delete exist
-      const expected1: TestType = {a: [1, 3]}
-      const updated1 = deepUpdate(data).at('a').at(1).set(DELETE)
+      // test if the element to delete is the first of the array
+      const expected1: TestType = {a: [2, 3]}
+      const updated1 = deepUpdate(data).at('a').at(0).set(DELETE)
       expect(updated1).toEqual(expected1)
       expect(updated1).toNotBe(data)
 
+      // test if the element to delete is in the middle of the array
+      const expected2: TestType = {a: [1, 3]}
+      const updated2 = deepUpdate(data).at('a').at(1).set(DELETE)
+      expect(updated2).toEqual(expected2)
+      expect(updated2).toNotBe(data)
+
+      // test if the element to delete is the last of the array
+      const expected3: TestType = {a: [1, 2]}
+      const updated3 = deepUpdate(data).at('a').at(2).set(DELETE)
+      expect(updated3).toEqual(expected3)
+      expect(updated3).toNotBe(data)
+
       // test if nothing happen when the element to delete is out of array's bound
-      const updated2 = deepUpdate(data).at('a').at(3).set(DELETE)
-      expect(updated2).toEqual(data)
+      const updated4 = deepUpdate(data).at('a').at(3).set(DELETE)
+      expect(updated4).toEqual(data)
 
       // test if nothing happen when the element to delete is widely out of array's bound
-      const updated3 = deepUpdate(data).at('a').at(5).set(DELETE)
-      expect(updated3).toEqual(data)
+      const updated5 = deepUpdate(data).at('a').at(5).set(DELETE)
+      expect(updated5).toEqual(data)
     })
 
     it('can update an union member with an instance of this union', () => {


### PR DESCRIPTION
https://github.com/AlexGalays/immupdate/issues/16

With this PR, trying to update an element which is out of bound of an array will do nothing (remove the ability to append an element at the end of an array).